### PR TITLE
Remove blocking header on Android by switching to Capacitor

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
-            android:theme="@style/AppTheme.NoActionBarLaunch"
+            android:theme="@style/AppTheme.NoActionBar"
             android:launchMode="singleTask"
             android:exported="true">
 

--- a/android/app/src/main/java/com/target/mobile/MainActivity.java
+++ b/android/app/src/main/java/com/target/mobile/MainActivity.java
@@ -1,23 +1,6 @@
 package com.target.mobile;
 
-import android.app.Activity;
-import android.os.Bundle;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
+import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends Activity {
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-
-        WebView webView = findViewById(R.id.webview);
-        webView.setWebViewClient(new WebViewClient()); // Ensures links open in the WebView
-
-        WebSettings webSettings = webView.getSettings();
-        webSettings.setJavaScriptEnabled(true); // Enable JS if needed
-
-        webView.loadUrl("https://target-web.netlify.app"); // Replace with your actual URL
-    }
+public class MainActivity extends BridgeActivity {
 }

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -15,6 +15,7 @@ const config: CapacitorConfig = {
     },
     StatusBar: {
       style: "dark",
+      overlaysWebView: true,
     },
     Keyboard: {
       resize: "body",


### PR DESCRIPTION
## Purpose
User reported that a header was blocking content on Android. This change addresses the issue by migrating from a custom WebView implementation to Capacitor's BridgeActivity, which provides better native integration and resolves the header blocking problem.

## Code changes
- **MainActivity.java**: Replaced custom Activity with WebView implementation with Capacitor's BridgeActivity
- **AndroidManifest.xml**: Updated theme from `AppTheme.NoActionBarLaunch` to `AppTheme.NoActionBar` 
- **capacitor.config.ts**: Added `overlaysWebView: true` to StatusBar configuration to prevent header overlap issues

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d5191b3740f8452f8abdad99c457b142/vibe-world)

👀 [Preview Link](https://d5191b3740f8452f8abdad99c457b142-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d5191b3740f8452f8abdad99c457b142</projectId>-->
<!--<branchName>vibe-world</branchName>-->