### PR TITLE
Fix MIME type error by scoping Express middleware to /api

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,8 @@ function expressPlugin(): Plugin {
       const app = createServer();
 
       // Add Express app as middleware to Vite dev server
-      server.middlewares.use(app);
+      // Only handle API routes, let Vite handle everything else
+      server.middlewares.use('/api', app);
     },
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ function expressPlugin(): Plugin {
 
       // Add Express app as middleware to Vite dev server
       // Only handle API routes, let Vite handle everything else
-      server.middlewares.use('/api', app);
+      server.middlewares.use("/api", app);
     },
   };
 }


### PR DESCRIPTION
## Purpose

The user was encountering a MIME type error where the server was responding with "text/html" instead of the expected JavaScript module script. This was happening because Express middleware was intercepting all requests, including those that should be handled by Vite's development server for serving JavaScript modules.

## Code changes

- Modified the Express middleware registration in `vite.config.ts` to only handle `/api` routes
- Added a comment explaining that API routes should go through Express while everything else should be handled by Vite
- This prevents Express from interfering with Vite's module serving, which was causing the MIME type mismatch

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f27e68a46d434003894933648f293da4/mystic-hub)

👀 [Preview Link](https://f27e68a46d434003894933648f293da4-mystic-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f27e68a46d434003894933648f293da4</projectId>-->
<!--<branchName>mystic-hub</branchName>-->